### PR TITLE
Add required imports

### DIFF
--- a/memstore.go
+++ b/memstore.go
@@ -2,9 +2,11 @@ package memstore
 
 import (
 	"bytes"
+	"encoding/base32"
 	"encoding/gob"
 	"fmt"
 	"net/http"
+	"strings"
 
 	"github.com/gorilla/securecookie"
 	"github.com/gorilla/sessions"


### PR DESCRIPTION
The commits updating keys on 20Sept are missing a couple of imports required by the code. Specifically, the code uses the encoding/base32 and strings packages, but those imports are not included in the source. This commit adds those necessary imports.